### PR TITLE
Fix unable to leave message android

### DIFF
--- a/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
+++ b/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
@@ -189,9 +189,7 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void startChat(ReadableMap options) {
-    setUserIdentity(options);
     setVisitorInfo(options);
-    setUserIdentity(options);
     String botName = getString(options,"botName");
     botName = botName == null ? "bot name" : botName;
     ChatConfiguration chatConfiguration = ChatConfiguration.builder()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-react-native-zendesk",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "React native wrapper for Zendesk Unified SDK",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR fix the bug that doesn't allow an Android user to leave a message after chatting with the initial chatbot.

The Android code has been aligned with the IOS code by removing the user identification when the chat starts.

**Before**

https://user-images.githubusercontent.com/11773070/140720063-702baaf6-58ff-4b39-9fd9-025c08e66ff5.mov

**After**

https://user-images.githubusercontent.com/11773070/140720474-3c05264b-157a-46b3-b066-7275ed7f88fe.mov

