### PR TITLE
Upgrade Zendesk SDK version

### DIFF
--- a/RNZendeskChat.podspec
+++ b/RNZendeskChat.podspec
@@ -18,8 +18,9 @@ Pod::Spec.new do |s|
   s.source_files   = 'ios/*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'ZendeskAnswerBotSDK'
-  s.dependency 'ZendeskSupportSDK', '~> 5.0.5'
-  s.dependency 'ZendeskChatSDK'
+  s.dependency 'ZendeskAnswerBotSDK', '~> 2.1.3'
+  s.dependency 'ZendeskSupportSDK', '~> 5.3.0'
+  s.dependency 'ZendeskChatSDK' '~> 2.11.1'
+  s.dependency 'ZendeskMessagingAPISDK', '~> 3.8.2'
   s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end

--- a/RNZendeskChat.podspec
+++ b/RNZendeskChat.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.dependency 'React'
   s.dependency 'ZendeskAnswerBotSDK', '~> 2.1.3'
   s.dependency 'ZendeskSupportSDK', '~> 5.3.0'
-  s.dependency 'ZendeskChatSDK' '~> 2.11.1'
+  s.dependency 'ZendeskChatSDK', '~> 2.11.1'
   s.dependency 'ZendeskMessagingAPISDK', '~> 3.8.2'
   s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,9 +33,9 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api group: 'com.zendesk', name: 'chat', version: '3.1.0'
-    api group: 'com.zendesk', name: 'answerbot', version: '3.0.1'
-    api group: 'com.zendesk', name: 'messaging', version: '5.1.0'
-    api group: 'com.zendesk', name: 'support', version: '5.0.2'
+    api group: 'com.zendesk', name: 'chat', version: '3.3.2'
+    api group: 'com.zendesk', name: 'answerbot', version: '3.0.4'
+    api group: 'com.zendesk', name: 'messaging', version: '5.2.2'
+    api group: 'com.zendesk', name: 'support', version: '5.0.5'
 }
-  
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-react-native-zendesk",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "React native wrapper for Zendesk Unified SDK",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR ugrade the Zendesk SDK both in Android and IOS:

**Android**
- `chat`: from 3.1.0 to **3.3.2**
- `answerbot`: from 3.0.1 to **3.0.4**
- `messaging`: from 5.1.0 to **5.2.2**
- `support`: from 5.0.2 to **5.0.5**

**IOS**

- `ZendeskAnswerBotSDK`: from 2.0.5 to **2.1.3**
- `ZendeskSupportSDK`: from 5.0.5 to **5.3.0**
- `ZendeskChatSDK`: from 2.7.0 to **2.11.1**
- `ZendeskMessagingAPISDK`: from 3.6.0 to **3.8.2**