### PR TITLE
Manage support operation

### DIFF
--- a/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
+++ b/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
@@ -166,17 +166,28 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void openTicket(){
+      Activity activity = getCurrentActivity();
+
+      // Custom Field for the category
+      CustomField customFieldOne = new CustomField(1900002821093L, "Cashback");
+
+      // Open a ticket
+      RequestActivity.builder().
+        withCustomFields(Arrays.asList(customFieldOne)).show(activity);
+  }
+
+  @ReactMethod
+  public void showTickets(){
+      Activity activity = getCurrentActivity();
+
+      // Show the user's tickets
+      RequestListActivity.builder().show(activity);
+  }
+
+  @ReactMethod
   public void showHelpCenter(ReadableMap options) {
     Activity activity = getCurrentActivity();
-    /*
-    // config must be passed as 2nd parameter to show method
-    List<CustomField> customFields = new ArrayList<>();
-    customFields.add(new CustomField(360028434358L, "testValoreDaApp"));
-    Configuration config = RequestActivity.builder()
-      .withCustomFields(customFields)
-      .withTags("tag1","tag2")
-      .config();
-     */
     Boolean withChat = getBoolean(options,"withChat");
     Boolean disableTicketCreation = getBoolean(options,"withChat");
     if (withChat) {

--- a/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
+++ b/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
@@ -169,12 +169,13 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
   public void openTicket(){
       Activity activity = getCurrentActivity();
 
+      List<CustomField> customFields = new ArrayList<>();
       // Custom Field for the category
-      CustomField customFieldOne = new CustomField(1900002821093L, "Cashback");
+      customFields.add(new CustomField(1900002821093L, "Cashback"));
 
       // Open a ticket
       RequestActivity.builder().
-        withCustomFields(Arrays.asList(customFieldOne)).show(activity);
+        withCustomFields(customFields).show(activity);
   }
 
   @ReactMethod

--- a/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
+++ b/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
@@ -39,6 +39,7 @@ import zendesk.answerbot.AnswerBot;
 import zendesk.answerbot.AnswerBotEngine;
 import zendesk.support.SupportEngine;
 import zendesk.support.request.RequestActivity;
+import zendesk.support.requestlist.RequestListActivity;
 
 public class RNZendeskChat extends ReactContextBaseJavaModule {
 

--- a/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
+++ b/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
@@ -170,10 +170,6 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
   public void openTicket(){
       Activity activity = getCurrentActivity();
 
-      List<CustomField> customFields = new ArrayList<>();
-      // Custom Field for the category
-      customFields.add(new CustomField(1900002821093L, "Cashback"));
-
       // Open a ticket
       RequestActivity.builder().
         withCustomFields(customFields).show(activity);

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,12 @@ declare module 'io-react-native-zendesk' {
   // function to display help center UI
   export function showHelpCenter(chatOptions: ChatOptions): void;
 
+  // function to open a ticket
+  export function openTicket(): void;
+
+  // function to shows all the tickets of the user
+  export function showTickets(): void;
+
   // function to set visitor info in chat
   export function setVisitorInfo(visitorInfo: UserInfo): void;
 

--- a/ios/RNZendeskChat.m
+++ b/ios/RNZendeskChat.m
@@ -60,7 +60,6 @@ RCT_EXPORT_METHOD(startChat:(NSDictionary *)options) {
 }
 
 RCT_EXPORT_METHOD(openTicket) {
-  [self setVisitorInfo:options];
 
   dispatch_sync(dispatch_get_main_queue(), ^{
     [self openTicketFunction];
@@ -150,13 +149,13 @@ RCT_EXPORT_METHOD(setNotificationToken:(NSData *)deviceToken) {
     [topController presentViewController:navControl animated:YES completion:nil];
 }
 
-- (void) openTicket {
+- (void) openTicketFunction {
     UIViewController *requestList = [ZDKRequestUi buildRequestUiWith:@[]];
     UIViewController *topController = [UIApplication sharedApplication].keyWindow.rootViewController;
     while (topController.presentedViewController) {
         topController = topController.presentedViewController;
     }
-    UINavigationController *navControl = [[UINavigationController alloc] initWithRootViewController: controller];
+    UINavigationController *navControl = [[UINavigationController alloc] initWithRootViewController: requestList];
     [navControl pushViewController:requestList animated:YES];
     [topController presentViewController:navControl animated:YES completion:nil];
   }

--- a/ios/RNZendeskChat.m
+++ b/ios/RNZendeskChat.m
@@ -59,6 +59,14 @@ RCT_EXPORT_METHOD(startChat:(NSDictionary *)options) {
   });
 }
 
+RCT_EXPORT_METHOD(openTicket) {
+  [self setVisitorInfo:options];
+
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    [self openTicketFunction];
+  });
+}
+
 RCT_EXPORT_METHOD(showHelpCenter:(NSDictionary *)options) {
   [self setVisitorInfo:options];
   dispatch_sync(dispatch_get_main_queue(), ^{
@@ -141,6 +149,17 @@ RCT_EXPORT_METHOD(setNotificationToken:(NSData *)deviceToken) {
     UINavigationController *navControl = [[UINavigationController alloc] initWithRootViewController: controller];
     [topController presentViewController:navControl animated:YES completion:nil];
 }
+
+- (void) openTicket {
+    UIViewController *requestList = [ZDKRequestUi buildRequestUiWith:@[]];
+    UIViewController *topController = [UIApplication sharedApplication].keyWindow.rootViewController;
+    while (topController.presentedViewController) {
+        topController = topController.presentedViewController;
+    }
+    UINavigationController *navControl = [[UINavigationController alloc] initWithRootViewController: controller];
+    [navControl pushViewController:requestList animated:YES];
+    [topController presentViewController:navControl animated:YES completion:nil];
+  }
 
 - (void) startChatFunction:(NSDictionary *)options {
     ZDKMessagingConfiguration *messagingConfiguration = [[ZDKMessagingConfiguration alloc] init];

--- a/ios/RNZendeskChat.m
+++ b/ios/RNZendeskChat.m
@@ -60,9 +60,13 @@ RCT_EXPORT_METHOD(startChat:(NSDictionary *)options) {
 }
 
 RCT_EXPORT_METHOD(openTicket) {
-
   dispatch_sync(dispatch_get_main_queue(), ^{
     [self openTicketFunction];
+  });
+}
+RCT_EXPORT_METHOD(showTickets) {
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    [self showTicketsFunction];
   });
 }
 
@@ -150,13 +154,22 @@ RCT_EXPORT_METHOD(setNotificationToken:(NSData *)deviceToken) {
 }
 
 - (void) openTicketFunction {
-    UIViewController *requestList = [ZDKRequestUi buildRequestUiWith:@[]];
+    UIViewController *openTicketController = [ZDKRequestUi buildRequestUiWith:@[]];
     UIViewController *topController = [UIApplication sharedApplication].keyWindow.rootViewController;
     while (topController.presentedViewController) {
         topController = topController.presentedViewController;
     }
-    UINavigationController *navControl = [[UINavigationController alloc] initWithRootViewController: requestList];
-    [navControl pushViewController:requestList animated:YES];
+    UINavigationController *navControl = [[UINavigationController alloc] initWithRootViewController: openTicketController];
+    [topController presentViewController:navControl animated:YES completion:nil];
+  }
+
+- (void) showTicketsFunction {
+    UIViewController *showTicketsController = [ZDKRequestUi buildRequestListWith:@[]];
+    UIViewController *topController = [UIApplication sharedApplication].keyWindow.rootViewController;
+    while (topController.presentedViewController) {
+        topController = topController.presentedViewController;
+    }
+    UINavigationController *navControl = [[UINavigationController alloc] initWithRootViewController: showTicketsController];
     [topController presentViewController:navControl animated:YES completion:nil];
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-react-native-zendesk",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "React native wrapper for Zendesk Unified SDK",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Short description
This PR adds the interface and the implementation of 2 functions that exploit the Zendesk [support package](https://developer.zendesk.com/documentation/classic-web-widget-sdks/support-sdk/android/nutshell/) instead of the [unified package](https://developer.zendesk.com/documentation/classic-web-widget-sdks/unified-sdk/android/introduction/).

## List of changes proposed in this pull request
- Added the method `openTicket` that allow a user to open a ticket
- Added the method `showTickets` that allow a user to see the list of his ticket.
- Upgraded the version to **0.3.7**



|  **openTicket** | **showTickets** |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/11773070/143250688-494e6597-8145-4bf2-98cd-902347fb838a.png" width=300>  | <img src="https://user-images.githubusercontent.com/11773070/143250727-fe2b4981-2424-488e-8d75-0d4266b455ee.png" width=300>  |

## How to test
Install the library and call the to methods with:
```
import ZendDesk from "io-react-native-zendesk";

<ButtonDefaultOpacity
        onPress={() => ZendDesk.openTicket()}
>...</ButtonDefaultOpacity>

<ButtonDefaultOpacity
        onPress={() => ZendDesk.showTickets()}
>...</ButtonDefaultOpacity>
```
