### PR TITLE
Upgrade version to 0.3.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-react-native-zendesk",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "React native wrapper for Zendesk Unified SDK",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR fix a bug introduced in the #6 increasing the version of the package that was mistakenly left the same: from **0.3.7** to **0.3.8**