### PR TITLE
Fix compilation error Android

### DIFF
--- a/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
+++ b/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
@@ -172,7 +172,7 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
 
       // Open a ticket
       RequestActivity.builder().
-        withCustomFields(customFields).show(activity);
+        show(activity);
   }
 
   @ReactMethod

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-react-native-zendesk",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "React native wrapper for Zendesk Unified SDK",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR fix an Android compilation error due to the use of an uninitialized variable.
It also upgrade the version to **0.3.9**