### PR TITLE
Update on response

### DIFF
--- a/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
+++ b/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
@@ -254,7 +254,7 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void hasNewResponse(final Promise promise){
+  public void getTotalNewResponses(final Promise promise){
     requestProvider = Support.INSTANCE.provider().requestProvider();
 
     requestProvider.getUpdatesForDevice(new ZendeskCallback<RequestUpdates>() {

--- a/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
+++ b/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
@@ -240,7 +240,7 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
     requestProvider.getUpdatesForDevice(new ZendeskCallback<RequestUpdates>() {
       @Override
       public void onSuccess(RequestUpdates requestUpdates) {
-        promise.resolve(requestUpdates.hasUpdatedRequests());
+        promise.resolve(requestUpdates.totalUpdates());
       }
 
       @Override

--- a/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
+++ b/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
@@ -38,6 +38,7 @@ import zendesk.core.Zendesk;
 import zendesk.support.CustomField;
 import zendesk.support.Request;
 import zendesk.support.RequestProvider;
+import zendesk.support.RequestUpdates;
 import zendesk.support.Support;
 import zendesk.support.guide.HelpCenterActivity;
 import zendesk.support.guide.ViewArticleActivity;
@@ -227,6 +228,23 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
       @Override
       public void onError(ErrorResponse errorResponse) {
         // Handle error
+        promise.reject(errorResponse.getReason());
+      }
+    });
+  }
+
+  @ReactMethod
+  public void hasNewResponse(final Promise promise){
+    requestProvider = Support.INSTANCE.provider().requestProvider();
+
+    requestProvider.getUpdatesForDevice(new ZendeskCallback<RequestUpdates>() {
+      @Override
+      public void onSuccess(RequestUpdates requestUpdates) {
+        promise.resolve(requestUpdates.hasUpdatedRequests());
+      }
+
+      @Override
+      public void onError(ErrorResponse errorResponse) {
         promise.reject(errorResponse.getReason());
       }
     });

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,8 +30,11 @@ declare module 'io-react-native-zendesk' {
   // function to shows all the tickets of the user
   export function showTickets(): void;
 
-  // function the return the number of tickets created by the user
+  // function that return the number of tickets created by the user
   export function hasOpenedTickets(): Promise<number>;
+
+  // function that return the number of unread messages by the user
+  export function hasNewResponse(): Promise<number>;
 
   // function to set visitor info in chat
   export function setVisitorInfo(visitorInfo: UserInfo): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,7 +37,7 @@ declare module 'io-react-native-zendesk' {
   export function hasOpenedTickets(): Promise<number>;
 
   // function that return the number of unread messages by the user
-  export function hasNewResponse(): Promise<number>;
+  export function getTotalNewResponses(): Promise<number>;
 
   // function to set visitor info in chat
   export function setVisitorInfo(visitorInfo: UserInfo): void;

--- a/ios/RNZendeskChat.m
+++ b/ios/RNZendeskChat.m
@@ -153,13 +153,8 @@ RCT_EXPORT_METHOD(hasNewResponse:(RCTPromiseResolveBlock)resolve rejecter:(RCTPr
 {
     ZDKRequestProvider * provider = [ZDKRequestProvider new];
         [provider getUpdatesForDeviceWithCallback:^(ZDKRequestUpdates * _Nullable requestUpdates) {
-            if (requestUpdates.hasUpdatedRequests) {
-                NSNumber *totalUpdates = [NSNumber numberWithInt:requestUpdates.totalUpdates];
-                resolve(totalUpdates);
-            } else {
-                // Since we cannot know if there is an error or if the user has not updates, resolve both cases with value 0
-                resolve(0);
-            }
+            NSNumber *totalUpdates = [NSNumber numberWithInt:requestUpdates.totalUpdates];
+            resolve(@[totalUpdates]);
         }];
 }
 - (UIColor *)colorFromHexString:(NSString *)hexString {

--- a/ios/RNZendeskChat.m
+++ b/ios/RNZendeskChat.m
@@ -129,7 +129,7 @@ RCT_EXPORT_METHOD(addTicketCustomField:(NSString *)key withValue:(NSString *)val
         [tags removeObjectAtIndex:0];
         i++;
     }
-    
+
 }
 RCT_EXPORT_METHOD(addTicketTag:(NSString *)tag) {
     [self initGlobals];
@@ -179,7 +179,7 @@ RCT_EXPORT_METHOD(hasOpenedTickets:(RCTPromiseResolveBlock)resolve rejecter:(RCT
         resolve(@[ticketsCount]);
     }];
 }
-RCT_EXPORT_METHOD(hasNewResponse:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(getTotalNewResponses:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
     ZDKRequestProvider * provider = [ZDKRequestProvider new];
         [provider getUpdatesForDeviceWithCallback:^(ZDKRequestUpdates * _Nullable requestUpdates) {

--- a/ios/RNZendeskChat.m
+++ b/ios/RNZendeskChat.m
@@ -149,7 +149,19 @@ RCT_EXPORT_METHOD(hasOpenedTickets:(RCTPromiseResolveBlock)resolve rejecter:(RCT
         resolve(@[ticketsCount]);
     }];
 }
-
+RCT_EXPORT_METHOD(hasNewResponse:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+    ZDKRequestProvider * provider = [ZDKRequestProvider new];
+        [provider getUpdatesForDeviceWithCallback:^(ZDKRequestUpdates * _Nullable requestUpdates) {
+            if (requestUpdates.hasUpdatedRequests) {
+                NSNumber *totalUpdates = [NSNumber numberWithInt:requestUpdates.totalUpdates];
+                resolve(totalUpdates);
+            } else {
+                // Since we cannot know if there is an error or if the user has not updates, resolve both cases with value 0
+                resolve(0);
+            }
+        }];
+}
 - (UIColor *)colorFromHexString:(NSString *)hexString {
     unsigned rgbValue = 0;
     NSScanner *scanner = [NSScanner scannerWithString:hexString];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-react-native-zendesk",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "React native wrapper for Zendesk Unified SDK",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR adds the interface that allows getting the number of unread messages.

Note that before calling `hasNewResponse` method initialization is needed. Every time you perform the initialization steps the result is refreshed, otherwise, the result is refreshed every hour.

In the video you can see the response of the method and the 2 unread messages.

https://user-images.githubusercontent.com/11773070/152843997-40e8b3be-368f-4190-b913-0b791b7b12de.mov

## How to test
I suggest the following steps:
- add the method in `ts/utils/supportAssistance.ts`
- in `ts/features/zendesk/saga/networking/handleHasOpenedTickets.ts` substitute the `hasOpenedTickets` call with the `hasNewResponse`
- Press the ask assistance button "`?`"
- Check the result