### PR TITLE
In showTicketsFunction currentController isn't updated

### DIFF
--- a/ios/RNZendeskChat.m
+++ b/ios/RNZendeskChat.m
@@ -266,6 +266,7 @@ RCT_EXPORT_METHOD(getTotalNewResponses:(RCTPromiseResolveBlock)resolve rejecter:
     while (topController.presentedViewController) {
         topController = topController.presentedViewController;
     }
+    currentController = topController;
     UINavigationController *navControl = [[UINavigationController alloc] initWithRootViewController: showTicketsController];
     [topController presentViewController:navControl animated:YES completion:nil];
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-react-native-zendesk",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "React native wrapper for Zendesk Unified SDK",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR fixes a bug related to https://github.com/pagopa/io-react-native-zendesk/pull/18
This causes that the Zendesk view about the tickets list won't be never dismissed by using the command `dismiss`