### PR TITLE
[IA-732] Hide open ticket button from ticket list screen in Android

### DIFF
--- a/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
+++ b/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
@@ -275,6 +275,7 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
 
     // Show the user's tickets
     RequestListActivity.builder()
+      .withContactUsButtonVisible(false)
       .show(activity);
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-react-native-zendesk",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "React native wrapper for Zendesk Unified SDK",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR hides the open ticket button when the user enters the ticket list screen in Android (IOS already respects this request). 

<img width="335" alt="image" src="https://user-images.githubusercontent.com/11773070/158204363-efd5501e-61f4-4a0c-b220-9f3fd1086b3a.png" width=300>

## How to test
Run the app on Android and try to enter it in the ticket list screen.