### PR TITLE
Extract reset functions

### DIFF
--- a/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
+++ b/android/src/main/java/com/saranshmalik/rnzendeskchat/RNZendeskChat.java
@@ -67,10 +67,18 @@ public class RNZendeskChat extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void reset() {
-    log.delete(0, log.length());
+  public void resetCustomFields() {
     customFields.clear();
+  }
+
+  @ReactMethod
+  public void resetTags() {
     tags.clear();
+  }
+
+  @ReactMethod
+  public void resetLog() {
+    log.delete(0, log.length());
   }
 
   @Override

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,8 +24,14 @@ declare module 'io-react-native-zendesk' {
   // add a new tag to the ticket
   export function addTicketTag(tag: string)
 
-  // remove log data and custom fields
-  export function reset(): void;
+  // remove custom fields
+  export function resetCustomFields(): void;
+
+  // remove tags
+  export function resetTags(): void;
+
+  // remove log data
+  export function resetLog(): void;
 
   // iOS only - close the current zendesk view (ticket creation, tickets list) if any
   export function dismiss(): void;

--- a/ios/RNZendeskChat.m
+++ b/ios/RNZendeskChat.m
@@ -93,11 +93,17 @@ UIViewController *currentController;
 #define MAX_TAGS_LENGTH 100
 #endif
 
-RCT_EXPORT_METHOD(reset) {
+RCT_EXPORT_METHOD(resetCustomFields) {
+    [self initGlobals];
+    [customFields removeAllObjects];
+}
+RCT_EXPORT_METHOD(resetTags) {
+    [self initGlobals];
+    [tags removeAllObjects];
+}
+RCT_EXPORT_METHOD(resetLog) {
     [self initGlobals];
     [mutableLog setString:@""];
-    [customFields removeAllObjects];
-    [tags removeAllObjects];
 }
 
 // dismiss the current controller shown, if any

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "io-react-native-zendesk",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "description": "React native wrapper for Zendesk Unified SDK",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR separates the reset function in 3 different reset functions:
- `resetCustomFields`
- `resetTags`
- `resetLog`

This allows the user to call it in a more flexible way.

## How to test
Check that both in IOS and Android the:
- `customFields`, `log`, `tags` (Android)
- `mutableLog`, `customFields`, `tags`

fields are empty after calling the respective function