### PR TITLE
build: update zendesk sdks to support iOS 16

### DIFF
--- a/RNZendeskChat.podspec
+++ b/RNZendeskChat.podspec
@@ -12,15 +12,15 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.source         = { git: "https://github.com/Saranshmalik/react-native-zendesk.git" }
   s.requires_arc   = true
-  s.platform       = :ios, '10.0'
+  s.platform       = :ios, '11.0'
 
   s.preserve_paths = 'LICENSE', 'README.md', 'package.json', 'index.js'
   s.source_files   = 'ios/*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'ZendeskAnswerBotSDK', '~> 2.1.3'
-  s.dependency 'ZendeskSupportSDK', '~> 5.3.0'
-  s.dependency 'ZendeskChatSDK', '~> 2.11.1'
-  s.dependency 'ZendeskMessagingAPISDK', '~> 3.8.2'
+  s.dependency 'ZendeskAnswerBotSDK', '~> 3.0.0'
+  s.dependency 'ZendeskSupportSDK', '~> 6.0.0'
+  s.dependency 'ZendeskChatSDK', '~> 3.0.0'
+  s.dependency 'ZendeskMessagingAPISDK', '~> 4.0.0'
   s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end


### PR DESCRIPTION
## Short description
This PR updates Zendesks SDKs to support iOS 16.
 
## List of changes proposed in this pull request
- Bump the platform version to iOS 11.0 to meet the minimum version for the [6.0.0 SDK.](https://developer.zendesk.com/documentation/classic-web-widget-sdks/support-sdk/ios/release_notes/?_ga=2.30189308.238227238.1682490582-830213268.1681302272#600);
- Bump `ZendeskAnswerBotSDK` version to `2.1.3`;
- Bump `ZendeskSupportSDK` version to `5.3.0`;
- Bump dependency `ZendeskChatSDK` to `2.11.1`;
- Bump dependency `ZendeskMessagingAPISDK`  to `3.8.2`.