### PR TITLE
ci: [IOPLT-000] Fix release of pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,4 +23,10 @@ jobs:
       - name: Build the library
         run: yarn prepare
       - name: Publish package on NPM 📦
-        run: npm publish
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" =~ [0-9]+\.[0-9]+\.[0-9]+-.+ ]]; then
+            npm publish --tag next
+          else
+            npm publish
+          fi


### PR DESCRIPTION
This pull request updates the NPM publishing workflow (as done [here](https://github.com/pagopa/io-app-design-system/commit/5b8765888c062152780440cc16d5b656a403ca1b)) to better handle pre-release versions. 

Now, when the version in `package.json` is a pre-release (e.g., contains a hyphen and label like `1.0.0-beta.1`), the package will be published with the `next` tag instead of the default `latest`.

- The NPM publish step now checks the package version and publishes pre-release versions (those matching `x.y.z-<label>`) with the `next` tag, ensuring stable and pre-release versions are tagged appropriately on NPM.